### PR TITLE
bug: resolve issue with databasecleaner so that it truncates between …

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -17,7 +17,7 @@ config.before(:suite) do
  end
 
  config.after(:each) do
-   DatabaseCleaner.clean
+   DatabaseCleaner.clean_with(:truncation)
  end
 
 end


### PR DESCRIPTION
…each test

We realised when we added in a new feature test that the user id was not being reset between each test, this had not been clear before as the test where the id matters was the first test run.

