### PR TITLE
admin: update gitignore for /vendor/bundle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3


### PR DESCRIPTION
Bug Issue #33

Added line in gitignore to cover vendor bundle files as recommended by:

https://github.com/github/gitignore/blob/master/Rails.gitignore