### PR TITLE
refactor: change db migrations to add user to posts separately

### DIFF
--- a/db/migrate/20190717160519_create_posts.rb
+++ b/db/migrate/20190717160519_create_posts.rb
@@ -3,7 +3,6 @@ class CreatePosts < ActiveRecord::Migration[5.1]
     create_table :posts do |t|
       t.string :message
       t.timestamps
-      t.belongs_to :user, index: true, foreign_key: true
     end
   end
 end

--- a/db/migrate/20190724104931_add_user_ref_to_posts.rb
+++ b/db/migrate/20190724104931_add_user_ref_to_posts.rb
@@ -1,0 +1,5 @@
+class AddUserRefToPosts < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :posts, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190717160519) do
+ActiveRecord::Schema.define(version: 20190724104931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
fix to create a migration which we can run in heroku to add users to posts in db.