### PR TITLE
Update time limit

### DIFF
--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,6 +1,23 @@
-<h1>UPDATE POST</h1>
-<%= form_for [current_user, @post] do |form| %>
-  <%= form.label :message %>
-  <%= form.text_area :message, size: "15x3", :value => @post.message %>
-  <%= form.submit "Submit" %>
+
+
+<%= @ten_mins_in_seconds = 600 %>
+<%= @post_creation_time = @post.created_at%>
+<%= created_at_time_plus_10mins = @post_creation_time + @ten_mins_in_seconds %>
+<%= Time.now %>
+
+
+
+<% if Time.now > created_at_time_plus_10mins %>
+  It's too late...
+  <%= Time.now %>
+  <%= created_at_time_plus_10mins %>
+  <%= flash.now[:error] = "You can no longer update this post" %>
+  <%= link_to "View Your Posts", user_posts_path(current_user) %>
+<% else %>
+  <h1>UPDATE POST</h1>
+  <%= form_for [current_user, @post] do |form| %>
+    <%= form.label :message %>
+    <%= form.text_area :message, size: "15x3", :value => @post.message %>
+    <%= form.submit "Submit" %>
+  <% end %>
 <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,11 +1,8 @@
 
 
-<%= @ten_mins_in_seconds = 600 %>
-<%= @post_creation_time = @post.created_at%>
-<%= created_at_time_plus_10mins = @post_creation_time + @ten_mins_in_seconds %>
-<%= Time.now %>
-
-
+<% @ten_mins_in_seconds = 600 %>
+<% @post_creation_time = @post.created_at%>
+<% created_at_time_plus_10mins = @post_creation_time + @ten_mins_in_seconds %>
 
 <% if Time.now > created_at_time_plus_10mins %>
   It's too late...

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -5,10 +5,8 @@
 <% created_at_time_plus_10mins = @post_creation_time + @ten_mins_in_seconds %>
 
 <% if Time.now > created_at_time_plus_10mins %>
-  It's too late...
-  <%= Time.now %>
-  <%= created_at_time_plus_10mins %>
   <%= flash.now[:error] = "You can no longer update this post" %>
+  <br>
   <%= link_to "View Your Posts", user_posts_path(current_user) %>
 <% else %>
   <h1>UPDATE POST</h1>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,7 @@ module Acebook
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = "London"
+    
   end
 end

--- a/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
+++ b/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature "Update my posts", type: :feature do
+  scenario "User tries to update post more than 10 mins after creation" do
+    sign_up
+    click_link "View Your Posts"
+    create_a_post("Hello")
+    click_link "Edit"
+    post_creation_date = Post.find(1).created_at
+    p "Post Creation date"
+    p post_creation_date
+    eleven_mins_in_seconds = 660
+    allow(Time).to receive(:now) {post_creation_date + eleven_mins_in_seconds}
+    p "Time now after stubbing"
+    p time_after =Time.now
+    p time_after > post_creation_date
+    p time_after < post_creation_date
+
+    expect(page).to have_content("You can no longer update this post")
+  end
+end

--- a/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
+++ b/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
@@ -5,17 +5,19 @@ RSpec.feature "Update my posts", type: :feature do
     sign_up
     click_link "View Your Posts"
     create_a_post("Hello")
-    click_link "Edit"
     post_creation_date = Post.find(1).created_at
-    p "Post Creation date"
-    p post_creation_date
     eleven_mins_in_seconds = 660
     allow(Time).to receive(:now) {post_creation_date + eleven_mins_in_seconds}
-    p "Time now after stubbing"
-    p time_after =Time.now
-    p time_after > post_creation_date
-    p time_after < post_creation_date
-
+    click_link "Edit"
     expect(page).to have_content("You can no longer update this post")
   end
+
+  scenario "User tries to update post less than 10 mins after creation" do
+    sign_up
+    click_link "View Your Posts"
+    create_a_post("Hello")
+    click_link "Edit"
+    expect(page).to have_content("UPDATE")
+  end
+
 end

--- a/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
+++ b/spec/features/user_can_only_update_their_post_within_10min_of_creation_spec.rb
@@ -1,13 +1,16 @@
 require 'rails_helper'
 
 RSpec.feature "Update my posts", type: :feature do
+
   scenario "User tries to update post more than 10 mins after creation" do
     sign_up
     click_link "View Your Posts"
     create_a_post("Hello")
+
     post_creation_date = Post.find(1).created_at
     eleven_mins_in_seconds = 660
     allow(Time).to receive(:now) {post_creation_date + eleven_mins_in_seconds}
+
     click_link "Edit"
     expect(page).to have_content("You can no longer update this post")
   end


### PR DESCRIPTION
- a user should now only be able to update a post for 10 mins after they created it, if the current time is after this then they are shown an error message and given a link to follow back to their posts page